### PR TITLE
cm: add opt-out for exFAT

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -179,9 +179,6 @@ PRODUCT_PACKAGES += \
     htop \
     powertop \
     lsof \
-    mount.exfat \
-    fsck.exfat \
-    mkfs.exfat \
     mkfs.f2fs \
     fsck.f2fs \
     fibmap.f2fs \
@@ -192,6 +189,15 @@ PRODUCT_PACKAGES += \
     oprofiled \
     sqlite3 \
     strace
+
+WITH_EXFAT ?= true
+ifeq ($(WITH_EXFAT),true)
+TARGET_USES_EXFAT := true
+PRODUCT_PACKAGES += \
+    mount.exfat \
+    fsck.exfat \
+    mkfs.exfat
+endif
 
 # Openssh
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Allow global disable of exFAT through environment variable
WITH_EXFAT. Maintain exFAT as enabled by default.

Change-Id: I85e8b14c51441fe52bd185be83880419ee831d5c
